### PR TITLE
Watch OS Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftRSA",
-    platforms: [.iOS(.v13), .macOS(.v10_15)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .watchOS(.v6)],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Build succeeded but **test failed both on iOS and watchOS** using Xcode 13.2.1 (13C100)

```
SwiftRSATests/EncryptionAndDecryptionTests.swift:28: Fatal error: Unexpectedly found nil while unwrapping an Optional value
Error Domain=NSOSStatusErrorDomain Code=-34018 "Key generation failed, error -34018" UserInfo={numberOfErrorsDeep=0, NSDescription=Key generation failed, error -34018}
```